### PR TITLE
Waiting for child processes after firing kill signal

### DIFF
--- a/wwpdb/apps/wf_engine/wf_engine_utils/process/ProcessUtils.py
+++ b/wwpdb/apps/wf_engine/wf_engine_utils/process/ProcessUtils.py
@@ -134,6 +134,12 @@ class ProcessUtils(object):
         try:
             for pid in pidList:
                 os.kill(pid, mySignal)
+
+                try:
+                    os.waitpid(pid, 0)
+                    self.__lfh.write("+ProcessUtils.killProcessList() process %s cleaned from process table\n" % (str(pid)))
+                except OSError as e:
+                    self.__lfh.write("+ProcessUtils.killProcessList() error waiting for pid (%s), error %s\n" % (str(pid), e))
             return True
         except Exception as e:
             self.__lfh.write("+ProcessUtils.killProcessList() failing with (%s)\n" % (str(e)))


### PR DESCRIPTION
The problem was that after killing all child processes the parent process was not waiting for them to finish or handling their signals